### PR TITLE
feat: bulletinBoard 페이지 좋아요 아이콘 바뀌기 기능 추가(실패) 및 UnderNav 컴포터넌트 각 페이지별 추가

### DIFF
--- a/unimeet/src/pages/bulletinBoard.tsx
+++ b/unimeet/src/pages/bulletinBoard.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import styled from "styled-components";
 import { AiOutlineHeart } from "react-icons/ai";
 import { AiFillHeart } from "react-icons/ai";
+import UnderNav from "@/components/UnderNav";
 
 interface Post {
   id: number;
@@ -81,51 +82,54 @@ export default function BulletinBoard() {
   };
 
   return (
-    <MainBox>
-      <Article>
-        {data &&
-          data.map((each, index) => {
-            return (
-              <Post key={index}>
-                <Writer>
-                  <ProfileImageWrap>
-                    <ProfileImage
-                      src={each.profileImageUrl}
-                      alt="작성자 이미지 사진"
-                    ></ProfileImage>
-                  </ProfileImageWrap>
-                  <Name>{each.nickname}</Name>
-                </Writer>
-                {each.imageUrl !== "" && (
-                  <PictureWrap>
-                    <PictureImage
-                      src={each.imageUrl}
-                      alt="게시글 첨부 사진"
-                    ></PictureImage>
-                  </PictureWrap>
-                )}
-                <WritingBox>
-                  <Title>{each.title}</Title>
-                  <Text>{each.content}</Text>
-                </WritingBox>
-                <ReactionBox>
-                  <HeartWrap onClick={(e) => ClickLike(e, each.id)}>
-                    {likedPosts.includes(each.id) ? (
-                      <StyledLikedHeartIcon />
-                    ) : (
-                      <StyledHeartIcon />
-                    )}
-                    <LikesCount>{each.likes}</LikesCount>
-                  </HeartWrap>
-                  {/* <CommentWrap>
+    <>
+      <MainBox>
+        <Article>
+          {data &&
+            data.map((each, index) => {
+              return (
+                <Post key={index}>
+                  <Writer>
+                    <ProfileImageWrap>
+                      <ProfileImage
+                        src={each.profileImageUrl}
+                        alt="작성자 이미지 사진"
+                      ></ProfileImage>
+                    </ProfileImageWrap>
+                    <Name>{each.nickname}</Name>
+                  </Writer>
+                  {each.imageUrl !== "" && (
+                    <PictureWrap>
+                      <PictureImage
+                        src={each.imageUrl}
+                        alt="게시글 첨부 사진"
+                      ></PictureImage>
+                    </PictureWrap>
+                  )}
+                  <WritingBox>
+                    <Title>{each.title}</Title>
+                    <Text>{each.content}</Text>
+                  </WritingBox>
+                  <ReactionBox>
+                    <HeartWrap onClick={(e) => ClickLike(e, each.id)}>
+                      {likedPosts.includes(each.id) ? (
+                        <StyledLikedHeartIcon />
+                      ) : (
+                        <StyledHeartIcon />
+                      )}
+                      <LikesCount>{each.likes}</LikesCount>
+                    </HeartWrap>
+                    {/* <CommentWrap>
                     <Comment src="/comment.png" alt="댓글" />
                   </CommentWrap> */}
-                </ReactionBox>
-              </Post>
-            );
-          })}
-      </Article>
-    </MainBox>
+                  </ReactionBox>
+                </Post>
+              );
+            })}
+        </Article>
+      </MainBox>
+      <UnderNav />
+    </>
   );
 }
 

--- a/unimeet/src/pages/bulletinBoard.tsx
+++ b/unimeet/src/pages/bulletinBoard.tsx
@@ -43,6 +43,8 @@ export default function BulletinBoard() {
     getPostsData();
   }, [token]);
 
+  const [likedPosts, setLikedPosts] = useState<number[]>([]);
+
   const ClickLike = async (
     e: React.MouseEvent<HTMLButtonElement>,
     postId: number
@@ -60,6 +62,14 @@ export default function BulletinBoard() {
           "게시글 좋아요",
           { headers }
         );
+
+        // 좋아요한 포스트의 ID를 관리하는 상태 업데이트
+        if (likedPosts.includes(postId)) {
+          setLikedPosts(likedPosts.filter((id) => id !== postId));
+        } else {
+          setLikedPosts([...likedPosts, postId]);
+        }
+
         const updatedResponse = await axios.get(`${searchUrl}`, {
           headers,
         });
@@ -100,10 +110,13 @@ export default function BulletinBoard() {
                 </WritingBox>
                 <ReactionBox>
                   <HeartWrap onClick={(e) => ClickLike(e, each.id)}>
-                    <StyledHeartIcon />
+                    {likedPosts.includes(each.id) ? (
+                      <StyledLikedHeartIcon />
+                    ) : (
+                      <StyledHeartIcon />
+                    )}
                     <LikesCount>{each.likes}</LikesCount>
                   </HeartWrap>
-
                   {/* <CommentWrap>
                     <Comment src="/comment.png" alt="댓글" />
                   </CommentWrap> */}
@@ -111,7 +124,6 @@ export default function BulletinBoard() {
               </Post>
             );
           })}
-        <AiOutlineHeart />
       </Article>
     </MainBox>
   );
@@ -143,7 +155,7 @@ const Post = styled.div`
   width: 100%;
   height: auto;
 
-  border-top: solid 1px #bb8dfb;
+  border-bottom: solid 1px #bb8dfb;
 `;
 
 const Writer = styled.div`
@@ -241,6 +253,10 @@ const HeartWrap = styled.button`
 `;
 
 const StyledHeartIcon = styled(AiOutlineHeart)`
+  font-size: 2.5rem;
+`;
+
+const StyledLikedHeartIcon = styled(AiFillHeart)`
   font-size: 2.5rem;
 `;
 

--- a/unimeet/src/pages/guestBook.tsx
+++ b/unimeet/src/pages/guestBook.tsx
@@ -1,3 +1,4 @@
+import UnderNav from "@/components/UnderNav";
 import axios from "axios";
 import { ChangeEvent, FormEvent, useEffect, useState } from "react";
 import styled from "styled-components";
@@ -32,7 +33,7 @@ export default function GestBook() {
             Authorization: `Bearer ${token}`,
           };
           const response = await axios.get(
-            "https://unimeet.duckdns.org/users/1/my-page?page=2", // 프로필 클릭시 users부분이 해당 학생 id로 바뀌게 수정 필요
+            "https://unimeet.duckdns.org/users/1/my-page?page=1", // 프로필 클릭시 users부분이 해당 학생 id로 바뀌게 수정 필요
             {
               headers,
             }
@@ -77,50 +78,53 @@ export default function GestBook() {
   };
 
   return (
-    <MainBox>
-      <DmButton src="/dmButton.png" alt="dmButton" />
-      <ProfileBox>
-        <ProfileImageWrap>
-          <ProfileImage
-            src={studentData?.profileImageUrl}
-            alt="profileImage"
-          ></ProfileImage>
-        </ProfileImageWrap>
-        <Name>{studentData?.nickname}</Name>
-        <InformationBox>
-          {/* {user?.majors.map((each, index) => (
+    <>
+      <MainBox>
+        <DmButton src="/dmButton.png" alt="dmButton" />
+        <ProfileBox>
+          <ProfileImageWrap>
+            <ProfileImage
+              src={studentData?.profileImageUrl}
+              alt="profileImage"
+            ></ProfileImage>
+          </ProfileImageWrap>
+          <Name>{studentData?.nickname}</Name>
+          <InformationBox>
+            {/* {user?.majors.map((each, index) => (
             <Department key={index}>
               <p>{each.major}</p> */}
-          <Department>{studentData?.department}</Department>
-          {/* ))} */}
-        </InformationBox>
-        <MBTI>
-          <p>{studentData?.mbti}</p>
-        </MBTI>
-        {/* <Introduce>{user?.introduction}</Introduce> */}
-      </ProfileBox>
-      <GuestBooks>
-        <GuestBookForm onSubmit={postGuestBook}>
-          <PostGuestBookCommentInputBox
-          placeholder="방명록을 남겨보세요."
-            onChange={onChange}
-          ></PostGuestBookCommentInputBox>
-        </GuestBookForm>
-        {guestBookData?.map((each, Id) => {
-          return (
-            <EachReview key={`writer${Id}`}>
-              <GuestImageWrap>
-                <GuestImage
-                  src={each.profileImageUrl}
-                  alt="profileImage"
-                ></GuestImage>
-              </GuestImageWrap>
-              <GuestComment>{each.content}</GuestComment>
-            </EachReview>
-          );
-        })}
-      </GuestBooks>
-    </MainBox>
+            <Department>{studentData?.department}</Department>
+            {/* ))} */}
+          </InformationBox>
+          <MBTI>
+            <p>{studentData?.mbti}</p>
+          </MBTI>
+          {/* <Introduce>{user?.introduction}</Introduce> */}
+        </ProfileBox>
+        <GuestBooks>
+          <GuestBookForm onSubmit={postGuestBook}>
+            <PostGuestBookCommentInputBox
+              placeholder="방명록을 남겨보세요."
+              onChange={onChange}
+            ></PostGuestBookCommentInputBox>
+          </GuestBookForm>
+          {guestBookData?.map((each, Id) => {
+            return (
+              <EachReview key={`writer${Id}`}>
+                <GuestImageWrap>
+                  <GuestImage
+                    src={each.profileImageUrl}
+                    alt="profileImage"
+                  ></GuestImage>
+                </GuestImageWrap>
+                <GuestComment>{each.content}</GuestComment>
+              </EachReview>
+            );
+          })}
+        </GuestBooks>
+      </MainBox>
+      <UnderNav />
+    </>
   );
 }
 

--- a/unimeet/src/pages/meetingLogs.tsx
+++ b/unimeet/src/pages/meetingLogs.tsx
@@ -1,3 +1,4 @@
+import UnderNav from "@/components/UnderNav";
 import axios from "axios";
 import { useEffect, useState } from "react";
 import styled from "styled-components";
@@ -11,23 +12,26 @@ export default function MeetingLogs() {
   };
 
   return (
-    <Main>
-      <SwitchDiv>
-        <ReceivedRequestsBtn onClick={() => switchiBtn("received")}>
-          받은 신청함
-        </ReceivedRequestsBtn>
-        <SentRequestsBtn onClick={() => switchiBtn("sent")}>
-          보낸 신청함
-        </SentRequestsBtn>
-      </SwitchDiv>
-      {selectedBtn === "received" ? (
-        <ReceivedRequests />
-      ) : selectedBtn === "sent" ? (
-        <SentRequests />
-      ) : (
-        <ReceivedRequests />
-      )}
-    </Main>
+    <>
+      <Main>
+        <SwitchDiv>
+          <ReceivedRequestsBtn onClick={() => switchiBtn("received")}>
+            받은 신청함
+          </ReceivedRequestsBtn>
+          <SentRequestsBtn onClick={() => switchiBtn("sent")}>
+            보낸 신청함
+          </SentRequestsBtn>
+        </SwitchDiv>
+        {selectedBtn === "received" ? (
+          <ReceivedRequests />
+        ) : selectedBtn === "sent" ? (
+          <SentRequests />
+        ) : (
+          <ReceivedRequests />
+        )}
+      </Main>
+      <UnderNav />
+    </>
   );
 }
 


### PR DESCRIPTION
좋아요 아이콘 바뀌기 기능! 
실패 원인은 
개인 회원이 좋아요 누른 게시글의 postid를 저장하는 것이 없음
백엔드에서 저장 기능을 구현 해주면 좋겠음.